### PR TITLE
ignore env (chef default) & .venv (personal pick)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ db.sqlite3
 **/raven.py
 public/static/*
 venv/*
+.venv/*
+.env/*


### PR DESCRIPTION
https://github.com/poise/application_python uses .env as its virtualenv dir. Might as well ignore that too.